### PR TITLE
Use updated SmartThings API endpoint URLs

### DIFF
--- a/alfredworkflow/device_collector.py
+++ b/alfredworkflow/device_collector.py
@@ -47,7 +47,7 @@ def device_collector(query=""):
         try:
             deviceFile = open("devices.txt")
             for deviceDataString in deviceFile.readlines():
-                deviceData = string.split(deviceDataString, ":")
+                deviceData = string.split(deviceDataString, "|")
                 deviceEndpoint = deviceData[0].strip()
                 deviceLabel = deviceData[1].strip()
     
@@ -55,7 +55,7 @@ def device_collector(query=""):
                     if not deviceFilter.lower() in deviceLabel.lower():
                         continue
     
-                arg = "{deviceEndpoint}.{command}".format(deviceEndpoint=deviceEndpoint, command=command)
+                arg = "{deviceEndpoint}|{command}".format(deviceEndpoint=deviceEndpoint, command=command)
                 
                 title = deviceLabel
                 if command.__len__() > 1:

--- a/alfredworkflow/execute_command.py
+++ b/alfredworkflow/execute_command.py
@@ -4,11 +4,11 @@ from settings import PROTOCOL, HOSTNAME
 
 
 def execute_command(query=""):
-    args = string.split(query, ".")
+    args = string.split(query, "|")
     url = args[0]
     command = args[1]
 
-    url = "{protocol}://{hostname}{url}".format(protocol=PROTOCOL, hostname=HOSTNAME, url=url)
+    url = "{url}".format(protocol=PROTOCOL, hostname=HOSTNAME, url=url)
     
     requestBody = '{"command":"' + "{command}".format(command=command) + '"}'
     request = urllib2.Request(url, data=requestBody)

--- a/alfredworkflow/get_endpoints.py
+++ b/alfredworkflow/get_endpoints.py
@@ -16,5 +16,5 @@ jsonData = json.loads(the_page)
 # store "Alfred Workflow" endpoint url
 endpointFile = open("endpoints.txt", "w")
 for endpoint in jsonData:
-    endpointFile.write(endpoint["url"] + "\n")
+    endpointFile.write(endpoint["uri"] + "\n")
 endpointFile.close()

--- a/alfredworkflow/refresh_devices.py
+++ b/alfredworkflow/refresh_devices.py
@@ -21,7 +21,7 @@ def refresh_devices():
                 
                 for deviceType in ("switches", "locks"):
                     endpoint = endpoint.strip()
-                    url = "{protocol}://{hostname}{endpoint}/{deviceType}".format(protocol=PROTOCOL, hostname=HOSTNAME, endpoint=endpoint, deviceType=deviceType)
+                    url = "{endpoint}/{deviceType}".format(protocol=PROTOCOL, hostname=HOSTNAME, endpoint=endpoint, deviceType=deviceType)
 
                     req = urllib2.Request(url)
                     req.add_header('Authorization', "Bearer %s" % token)
@@ -32,11 +32,10 @@ def refresh_devices():
                     for device in jsonData:
                         deviceKey = "{endpoint}/{deviceType}/{deviceId}".format(endpoint=endpoint, deviceType=deviceType, deviceId=device['id'])                        
                         deviceValue = device['name'] if len(device['label']) == 0 else device['label']
-                        deviceCache = "{key}:{value}\n".format(key=deviceKey, value=deviceValue)
+                        deviceCache = "{key}|{value}\n".format(key=deviceKey, value=deviceValue)
                         devicesFile.write(deviceCache)
                         
     devicesFile.close()
     
     return "Your SmartThings device cache has been updated"
 
-    


### PR DESCRIPTION
The current code assumes that device/SmartApp endpoints will live at graph.api.smartthings.com. At some point SmartThings started using alternate URLs for SmartApp endpoints, e.g. `https://graph-na02-useast1.api.smartthings.com:443/...` which now breaks this implementation. 

This pull request allows SmartThings-Alfred to take advantage of the new URL structure, and makes a few delimiter changes along the way since previously used delimiters of ":" and "." are now found in the base endpoint URL. I confirmed these changes work on a current version of Alfred. The changes may need additional validation to handle unexpected results from the API.